### PR TITLE
Call [super prepareForReuse] in EasyTableViewCell

### DIFF
--- a/Classes/EasyTableView.m
+++ b/Classes/EasyTableView.m
@@ -22,10 +22,10 @@
 
 - (void) prepareForReuse
 {
-    UIView *content = [self viewWithTag:CELL_CONTENT_TAG];
+    [super prepareForReuse];
     
-    if ([content respondsToSelector:@selector(prepareForReuse)])
-    {
+    UIView *content = [self viewWithTag:CELL_CONTENT_TAG];
+    if ([content respondsToSelector:@selector(prepareForReuse)]) {
         [content performSelector:@selector(prepareForReuse)];
     }
 


### PR DESCRIPTION
From the UITableViewCell Class Reference:

>  If you override this method, you must be sure to invoke the superclass implementation.
