### PR TITLE
Fixed bug where custom cell background color was not set on cell.

### DIFF
--- a/Classes/EasyTableView.m
+++ b/Classes/EasyTableView.m
@@ -377,6 +377,8 @@
 		rotatedView.tag					= ROTATED_CELL_VIEW_TAG;
 		rotatedView.center				= cell.contentView.center;
 		rotatedView.backgroundColor		= self.cellBackgroundColor;
+        
+        cell.backgroundColor = self.cellBackgroundColor;
 		
 		if (_orientation == EasyTableViewOrientationHorizontal) {
 			rotatedView.autoresizingMask = UIViewAutoresizingFlexibleHeight;


### PR DESCRIPTION
All instances of EasyTableViewCell kept their default background color, no matter what value you gave to the cellBackgroundColor property on EasyTableView. Turns out it was never set on the cell.